### PR TITLE
Use web api to get wishlist and app data.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,10 @@
 repos:
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.6.3"
     hooks:
-      - id: isort
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.2
-    hooks:
-      - id: pyupgrade
-        args: [--py37-plus]
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black
-        args:
-          - --safe
-          - --quiet
-        files: ^((homeassistant|script|tests)/.+)?[^/]+\.py$
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: v1.17.1
     hooks:
@@ -25,33 +14,6 @@ repos:
           - --skip="./.*,*.csv,*.json"
           - --quiet-level=2
         exclude_types: [csv, json]
-  - repo: https://github.com/pycqa/flake8.git
-    rev: 3.8.3
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-docstrings==1.5.0
-          - pydocstyle==5.0.2
-        files: ^(homeassistant|script|tests)/.+\.py$
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.6.2
-    hooks:
-      - id: bandit
-        args:
-          - --quiet
-          - --format=custom
-          - --configfile=tests/bandit.yaml
-        files: ^(homeassistant|script|tests)/.+\.py$
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.5.3
-    hooks:
-      - id: isort
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
-    hooks:
-      - id: check-executables-have-shebangs
-        stages: [manual]
-      - id: check-json
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.9.0
     hooks:

--- a/custom_components/steam_wishlist/__init__.py
+++ b/custom_components/steam_wishlist/__init__.py
@@ -17,11 +17,12 @@ async def async_setup_entry(
     hass: core.HomeAssistant, entry: config_entries.ConfigEntry
 ) -> bool:
     """Set up platforms from a ConfigEntry."""
-    url = entry.data["url"]
-    # https://store.steampowered.com/wishlist/profiles/<steam-id>/wishlistdata/
-    steam_id = url.split("/")[-3]
+    steam_id = entry.data["steam_id"]
+    api_key = entry.data["key"]
     store_all_wishlist_items = entry.options.get("show_all_wishlist_items", False)
-    hass.data[DOMAIN][entry.entry_id] = SensorManager(hass, store_all_wishlist_items, url)
+    hass.data[DOMAIN][entry.entry_id] = SensorManager(
+        hass, store_all_wishlist_items, api_key, steam_id
+    )
 
     if not entry.unique_id:
         hass.config_entries.async_update_entry(
@@ -37,10 +38,13 @@ async def async_setup_entry(
     return True
 
 
-async def update_listener(hass: core.HomeAssistant, entry: config_entries.ConfigEntry) -> None:
+async def update_listener(
+    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
+) -> None:
     show_all = entry.options.get("show_all_wishlist_items", False)
     hass.data[DOMAIN][entry.entry_id].store_all_wishlist_items = show_all
     await hass.data[DOMAIN][entry.entry_id].coordinator.async_request_refresh()
+
 
 async def async_unload_entry(
     hass: core.HomeAssistant, entry: config_entries.ConfigEntry

--- a/custom_components/steam_wishlist/sensor_manager.py
+++ b/custom_components/steam_wishlist/sensor_manager.py
@@ -56,10 +56,12 @@ class SteamWishlistDataUpdateCoordinator(DataUpdateCoordinator):
             app_ids: list[int] = [
                 item["appid"] for item in wishlist_data["response"]["items"]
             ]
-
         input_json = {
             "ids": [{"appid": str(app_id)} for app_id in app_ids],
-            "context": {"language": "english", "country_code": "US"},
+            "context": {
+                "language": self.hass.config.language or "en",
+                "country_code": self.hass.config.country or "US",
+            },
             "data_request": {
                 "include_assets": True,
                 "include_reviews": True,

--- a/custom_components/steam_wishlist/sensor_manager.py
+++ b/custom_components/steam_wishlist/sensor_manager.py
@@ -1,5 +1,9 @@
+"""Coordinator and sensor manager for the integration."""
+
+from collections.abc import Callable
+import json
 import logging
-from typing import Any, Callable, Dict, List, Union
+from typing import Any
 
 from homeassistant import core
 from homeassistant.core import callback
@@ -15,8 +19,10 @@ from .util import get_steam_game
 _LOGGER = logging.getLogger(__name__)
 WISHLIST_ID = -1
 DEVICE_CONFIGURATION_URL = "https://store.steampowered.com/wishlist/profiles/{}/"
+GET_WISHLIST_URL = "https://api.steampowered.com/IWishlistService/GetWishlist/v1"
+GET_APPS_URL = "https://api.steampowered.com/IStoreBrowseService/GetItems/v1"
 
-SteamEntity = Union[SteamGameEntity, SteamWishlistEntity]
+SteamEntity = SteamGameEntity | SteamWishlistEntity
 
 
 class SteamWishlistDataUpdateCoordinator(DataUpdateCoordinator):
@@ -29,10 +35,9 @@ class SteamWishlistDataUpdateCoordinator(DataUpdateCoordinator):
     is scheduled.
     """
 
-    def __init__(self, hass: core.HomeAssistant, url: str) -> None:
-        self.url = url
-        # https://store.steampowered.com/wishlist/profiles/<steam-id>/wishlistdata/
-        self.steam_id = self.url.split("/")[-3]
+    def __init__(self, hass: core.HomeAssistant, api_key: str, steam_id: str) -> None:
+        self.api_key = api_key
+        self.steam_id = steam_id
         self.http_session = async_get_clientsession(hass)
         super().__init__(
             hass,
@@ -42,34 +47,35 @@ class SteamWishlistDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=SCAN_INTERVAL,
         )
 
-    async def _async_fetch_data(self) -> dict[str, dict[str, Any]]:
+    async def _async_fetch_data(self) -> dict[int, dict[str, Any]]:
         """Fetch the data for the coordinator."""
-        data: dict[str, dict[str, Any]] = {}
-        # Attempt to look up to 10 pages of data. There does not appear to be a static
-        # number of results returned, it seems random. There also isn't any indication
-        # in the response that to let us know there are more pages to fetch. An empty
-        # array will be returned if we request a page of results when a user doesn't
-        # have that many.
-        for page in range(10):
-            url = f"{self.url}?p={page}"
-            async with self.http_session.get(url) as resp:
-                result = await resp.json()
-                if not isinstance(result, dict):
-                    # An empty array will be returned if we request a page of results
-                    # when a user doesn't have that many. e.g. requesting page 2 when
-                    # they only have 1 page of results.
-                    break
-                data.update(result)
-                if len(result) <= 50:
-                    # Even though we don't know the number of results per page, it seems
-                    # to be well over 50, likely between 70-100. So don't bother a 2nd
-                    # request if the result is this small.
-                    break
+        async with self.http_session.get(
+            GET_WISHLIST_URL, params={"key": self.api_key, "steamid": self.steam_id}
+        ) as resp:
+            wishlist_data = await resp.json()
+            app_ids: list[int] = [
+                item["appid"] for item in wishlist_data["response"]["items"]
+            ]
 
-        return data
+        input_json = {
+            "ids": [{"appid": str(app_id)} for app_id in app_ids],
+            "context": {"language": "english", "country_code": "US"},
+            "data_request": {
+                "include_assets": True,
+                "include_reviews": True,
+                "include_basic_info": True,
+            },
+        }
+        async with self.http_session.get(
+            GET_APPS_URL,
+            params={"key": self.api_key, "input_json": json.dumps(input_json)},
+        ) as resp:
+            apps_data = await resp.json()
+            return {item["id"]: item for item in apps_data["response"]["store_items"]}
 
     @property
     def device_info(self) -> DeviceInfo:
+        """Return device info for the integration."""
         unique_id = self.config_entry.unique_id
         return DeviceInfo(
             identifiers={(DOMAIN, unique_id)},
@@ -114,12 +120,17 @@ class SensorManager:
     """
 
     def __init__(
-        self, hass: core.HomeAssistant, store_all_wishlist_items: bool, url: str
+        self,
+        hass: core.HomeAssistant,
+        store_all_wishlist_items: bool,
+        api_key: str,
+        steam_id: str,
     ) -> None:
         self.hass = hass
         self.store_all_wishlist_items = store_all_wishlist_items
-        self.url = url
-        self.coordinator = SteamWishlistDataUpdateCoordinator(hass, url)
+        self.steam_id = steam_id
+        self.api_key = api_key
+        self.coordinator = SteamWishlistDataUpdateCoordinator(hass, api_key, steam_id)
         self._component_add_entities = {}
         self.cleanup_jobs = []
         self.current_wishlist: dict[int, SteamEntity] = {}
@@ -153,26 +164,15 @@ class SensorManager:
 
         new_binary_sensors: list[SteamGameEntity] = []
 
-        process_data = True
-        if not isinstance(self.coordinator.data, dict):
-            # This seems to happen when we get an unexpected response.  This typically
-            # means an intermittent request failure. Data is then an empty dict. Should
-            # something different happen here?
-            _LOGGER.warning(
-                "Coordinator data unexpectedly not a dict: %s", self.coordinator.data
-            )
-            process_data = False
-        # {"success": 2} This CAN (but not always) indicate an empty wishlist.
-        if "success" not in self.coordinator.data and process_data:
-            for game_id, game in self.coordinator.data.items():
-                existing = self.current_wishlist.get(game_id)
-                if existing is not None:
-                    continue
+        for game_id, game in self.coordinator.data.items():
+            existing = self.current_wishlist.get(game_id)
+            if existing is not None:
+                continue
 
-                # Found a new game that we will need to create a new binary_sensor for.
-                steam_game = get_steam_game(game_id, game)
-                self.current_wishlist[game_id] = SteamGameEntity(self, steam_game)
-                new_binary_sensors.append(self.current_wishlist[game_id])
+            # Found a new game that we will need to create a new binary_sensor for.
+            steam_game = get_steam_game(game_id, game)
+            self.current_wishlist[game_id] = SteamGameEntity(self, steam_game)
+            new_binary_sensors.append(self.current_wishlist[game_id])
 
         if new_sensors:
             self._component_add_entities["sensor"](new_sensors)

--- a/custom_components/steam_wishlist/translations/en.json
+++ b/custom_components/steam_wishlist/translations/en.json
@@ -1,17 +1,18 @@
 {
   "config": {
     "error": {
-      "invalid_profile_id": "Could not find a Steam profile with the provided ID.",
-      "invalid_user": "Could not find a steam account associated with the provided name or your profile is not public, see https://github.com/boralyl/steam-wishlist#pre-installation",
-      "missing": "Enter your Steam account name or Steam profile ID."
+      "invalid_account_name": "Could not find a Steam profile with the provided name.",
+      "invalid_api_key": "The provided web API key is invalid."
     },
     "step": {
       "user": {
         "data": {
-          "steam_account_name": "Steam account name",
-          "steam_profile_id": "Steam profile id (e.g. 7656119383323351)"
+          "steam_account_name": "Steam Profile Name",
+          "steam_web_api_key": "Steam Web API Key"
         },
-        "description": "Enter EITHER your Steam account name OR your Steam profile ID.",
+        "data_description": {
+          "steam_web_api_key": "You can create or look up your api key here: https://steamcommunity.com/dev/apikey"
+        },
         "title": "Setup"
       }
     }

--- a/custom_components/steam_wishlist/types.py
+++ b/custom_components/steam_wishlist/types.py
@@ -1,13 +1,15 @@
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 
 class SteamGame(TypedDict):
+    """Represents a Steam Game."""
+
     box_art_url: str
-    normal_price: Optional[float]
+    normal_price: str | None
     percent_off: float
     reviews_desc: str
     reviews_percent: int
-    reviews_total: str
-    sale_price: Optional[float]
+    reviews_total: int
+    sale_price: str | None
     steam_id: int
     title: str

--- a/custom_components/steam_wishlist/util.py
+++ b/custom_components/steam_wishlist/util.py
@@ -1,83 +1,66 @@
-from datetime import datetime, timedelta, timezone
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 from .types import SteamGame
 
 _LOGGER = logging.getLogger(__name__)
+ASSET_BASE_URL = "https://shared.cloudflare.steamstatic.com/store_item_assets/"
 
-def get_release_date(game: dict[str, Any]) -> str:
-    release_date = game.get("release_date", "0")
-    if str(release_date).isdigit():
-        release_date_datetime = datetime.fromtimestamp(int(release_date), timezone.utc)
-        if datetime.now(timezone.utc) < release_date_datetime + timedelta(days=1):
-            return "Release date:&nbsp;&nbsp;" + release_date_datetime.strftime("%b %d, %Y") + "&nbsp;&nbsp;🆕"
-        else:
-            return "Released:&nbsp;&nbsp;" + release_date_datetime.strftime("%b %d, %Y")
-    else:
-        return "Unknown"
 
-def get_steam_game(game_id: int, game: Dict) -> SteamGame:
+def get_steam_game(game_id: int, game: dict[str, Any]) -> SteamGame:
     """Get a SteamGame from a game dict."""
-    pricing: Optional[Dict[str, Any]] = None
-    try:
-        pricing: Dict[str, Any] = game["subs"][0]
-        discount_pct = pricing["discount_pct"] or 0
-    except IndexError:
-        # This typically means this game is not yet released so pricing is not known.
-        pricing = None
-        discount_pct = 0
-
-    normal_price: Optional[float] = None
-    if pricing:
-        price = int(pricing["price"])
-        if discount_pct == 100:
-            normal_price = price
+    pricing: dict[str, Any] | None = None
+    discount_pct: float = 0
+    normal_price: str | None = None
+    sale_price: str | None = None
+    if (pricing := game.get("best_purchase_option")) is not None:
+        discount_pct = pricing.get("discount_pct", 0)
+        if not discount_pct:
+            normal_price = pricing["formatted_final_price"]
         else:
-            normal_price = round(price / (100 - discount_pct), 2)
+            normal_price = pricing["formatted_original_price"]
+            sale_price = pricing["formatted_final_price"]
 
-    sale_price: Optional[float] = None
-    if pricing and discount_pct:
-        # Price is an integer so $6.00 is 600.
-        sale_price = round(int(pricing["price"]) * 0.01, 2)
-
-    reviews_percent = game.get('reviews_percent', 'N/A')
-    review_desc = game.get('review_desc', 'No reviews')
+    reviews = game.get("reviews", {}).get("summary_filtered", {})
+    reviews_percent = reviews.get("percent_positive", "N/A")
+    review_desc = reviews.get("review_score_label", "No reviews")
     rating_info = f"Reviews:&nbsp;&nbsp;{reviews_percent}% ({review_desc})"
+    review_count = reviews.get("review_count", 0)
 
     try:
-        original_price = float(normal_price if normal_price is not None else 0)
-        sale_price_val = float(sale_price if sale_price is not None else original_price)
-        discount_percentage = int(discount_pct) if discount_pct is not None else 0
-        if original_price == 0:
+        if normal_price is None:
             price_info = "Price:&nbsp;&nbsp;TBD"
+        elif sale_price is not None:
+            strikethrough_price = (
+                "".join(ch + "\u0336" for ch in normal_price[:-1]) + normal_price[-1]
+            )
+            price_info = f"{strikethrough_price} {sale_price} ({discount_pct}% off)&nbsp;&nbsp;🎫"
         else:
-            original_price_formatted = f"{original_price:.2f}"
-            if sale_price is not None:
-                strikethrough_price = ''.join(ch + "\u0336" for ch in original_price_formatted[:-1]) + original_price_formatted[-1]
-                price_info = f"{strikethrough_price} ${sale_price_val:.2f} ({discount_percentage}% off)&nbsp;&nbsp;🎫"
-            else:
-                price_info = f"Price:&nbsp;&nbsp;${original_price:.2f}"
+            price_info = f"Price:&nbsp;&nbsp;{normal_price}"
     except (ValueError, TypeError):
         price_info = "Price information unavailable"
 
+    image_url_format = game["assets"]["asset_url_format"]
+    capsule = game["assets"]["main_capsule"]
+    image_path = image_url_format.replace("${FILENAME}", capsule)
+    image_url = f"{ASSET_BASE_URL}{image_path}"
     game: SteamGame = {
         "title": game["name"],
         "rating": rating_info,
         "price": price_info,
-        "genres": ", ".join(game.get("tags", [])),
-        "release": get_release_date(game),
-        "airdate": game.get("release_date", ""),
+        "genres": "",
+        "release": "",
+        "airdate": "unknown",
         "normal_price": normal_price,
         "percent_off": discount_pct,
-        "review_desc": game.get("review_desc", "No user reviews"),
-        "reviews_percent": game.get("reviews_percent", 0),
-        "reviews_total": game.get("reviews_total", "0"),
+        "review_desc": review_desc,
+        "reviews_percent": reviews_percent,
+        "reviews_total": review_count,
         "sale_price": sale_price,
-        "steam_id": game_id,
-        "box_art_url": game["capsule"],
-        "fanart": game.get("capsule"),
-        "poster": game.get("capsule"),
+        "steam_id": str(game_id),
+        "box_art_url": image_url,
+        "fanart": image_url,
+        "poster": image_url,
         "deep_link": f"https://store.steampowered.com/app/{game_id}",
     }
     return game

--- a/custom_components/steam_wishlist/util.py
+++ b/custom_components/steam_wishlist/util.py
@@ -40,10 +40,14 @@ def get_steam_game(game_id: int, game: dict[str, Any]) -> SteamGame:
     except (ValueError, TypeError):
         price_info = "Price information unavailable"
 
-    image_url_format = game["assets"]["asset_url_format"]
-    capsule = game["assets"]["main_capsule"]
-    image_path = image_url_format.replace("${FILENAME}", capsule)
-    image_url = f"{ASSET_BASE_URL}{image_path}"
+    try:
+        image_url_format = game["assets"]["asset_url_format"]
+        capsule = game["assets"]["main_capsule"]
+        image_path = image_url_format.replace("${FILENAME}", capsule)
+        image_url = f"{ASSET_BASE_URL}{image_path}"
+    except KeyError:
+        image_url = None
+
     game: SteamGame = {
         "title": game["name"],
         "rating": rating_info,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """pytest fixtures."""
+
 from unittest.mock import Mock
 
 from aioresponses import aioresponses
@@ -19,107 +20,153 @@ def mock_aioresponse():
 
 
 @pytest.fixture
-def coordinator_mock(hass):
+def game_on_sale_response_item():
+    """Fixture to return an on sale steam game response item."""
+    return {
+        "item_type": 0,
+        "id": 1220150,
+        "success": 1,
+        "visible": True,
+        "name": "Blue Fire",
+        "store_url_path": "app/1220150/Blue_Fire",
+        "appid": 1220150,
+        "type": 0,
+        "categories": {
+            "supported_player_categoryids": [2],
+            "feature_categoryids": [22, 23, 43, 62],
+            "controller_categoryids": [28],
+        },
+        "reviews": {
+            "summary_filtered": {
+                "review_count": 1623,
+                "percent_positive": 84,
+                "review_score": 8,
+                "review_score_label": "Very Positive",
+            }
+        },
+        "basic_info": {
+            "short_description": "Embark on an extraordinary adventure through the perished world of Penumbra to explore unique temples filled with increasingly difficult 3D platforming challenges, diverse enemies, quests, collectibles, and more. Slash daunting adversaries, leap through deadly traps and master the art of movement.",
+            "publishers": [
+                {"name": "Graffiti Games", "creator_clan_account_id": 35843170}
+            ],
+            "developers": [
+                {"name": "Robi Studios", "creator_clan_account_id": 44788856}
+            ],
+            "franchises": [
+                {"name": "Blue Fire", "creator_clan_account_id": 44788856},
+                {"name": "Graffiti Games", "creator_clan_account_id": 35843170},
+            ],
+        },
+        "assets": {
+            "asset_url_format": "steam/apps/1220150/${FILENAME}?t=1655302580",
+            "main_capsule": "capsule_616x353.jpg",
+            "small_capsule": "capsule_231x87.jpg",
+            "header": "header.jpg",
+            "page_background": "page_bg_generated_v6b.jpg",
+            "library_capsule": "library_600x900.jpg",
+            "library_capsule_2x": "library_600x900_2x.jpg",
+            "library_hero": "library_hero.jpg",
+            "community_icon": "db04631967d673b165ca802969706557cdbc2d84",
+        },
+        "best_purchase_option": {
+            "packageid": 422570,
+            "purchase_option_name": "Blue Fire",
+            "final_price_in_cents": "499",
+            "original_price_in_cents": "1999",
+            "formatted_final_price": "$4.99",
+            "formatted_original_price": "$19.99",
+            "discount_pct": 75,
+            "active_discounts": [
+                {
+                    "discount_amount": "1500",
+                    "discount_description": "#discount_desc_preset_special",
+                    "discount_end_date": 1734544800,
+                }
+            ],
+            "user_can_purchase_as_gift": True,
+            "hide_discount_pct_for_compliance": False,
+            "included_game_count": 1,
+        },
+    }
+
+
+@pytest.fixture
+def game_response_item():
+    """Fixture to return a steam game response item."""
+    return {
+        "item_type": 0,
+        "id": 2215430,
+        "success": 1,
+        "visible": True,
+        "name": "Ghost of Tsushima DIRECTOR'S CUT",
+        "store_url_path": "app/2215430/Ghost_of_Tsushima_DIRECTORS_CUT",
+        "appid": 2215430,
+        "type": 0,
+        "content_descriptorids": [1, 2, 5],
+        "categories": {
+            "supported_player_categoryids": [2, 1, 9, 38],
+            "feature_categoryids": [22, 62],
+            "controller_categoryids": [28],
+        },
+        "reviews": {
+            "summary_filtered": {
+                "review_count": 33897,
+                "percent_positive": 93,
+                "review_score": 8,
+                "review_score_label": "Very Positive",
+            }
+        },
+        "basic_info": {
+            "short_description": "A storm is coming. Venture into the complete Ghost of Tsushima DIRECTOR’S CUT on PC; forge your own path through this open-world action adventure and uncover its hidden wonders. Brought to you by Sucker Punch Productions, Nixxes Software and PlayStation Studios.",
+            "publishers": [
+                {
+                    "name": "PlayStation Publishing LLC",
+                    "creator_clan_account_id": 40425349,
+                }
+            ],
+            "developers": [
+                {
+                    "name": "Sucker Punch Productions",
+                    "creator_clan_account_id": 40425349,
+                },
+                {"name": "Nixxes Software", "creator_clan_account_id": 40425349},
+            ],
+            "franchises": [
+                {"name": "PlayStation Studios", "creator_clan_account_id": 40425349}
+            ],
+        },
+        "assets": {
+            "asset_url_format": "steam/apps/2215430/${FILENAME}?t=1717622497",
+            "main_capsule": "capsule_616x353.jpg",
+            "small_capsule": "capsule_231x87.jpg",
+            "header": "header.jpg",
+            "page_background": "page_bg_generated_v6b.jpg",
+            "hero_capsule": "hero_capsule.jpg",
+            "library_capsule": "library_600x900.jpg",
+            "library_capsule_2x": "library_600x900_2x.jpg",
+            "library_hero": "library_hero.jpg",
+            "library_hero_2x": "library_hero_2x.jpg",
+            "community_icon": "e87b8cbe31f7bc5f40ee6ed94ccfa18f59f04fbc",
+        },
+        "best_purchase_option": {
+            "packageid": 793537,
+            "purchase_option_name": "Ghost of Tsushima DIRECTOR'S CUT",
+            "final_price_in_cents": "5999",
+            "formatted_final_price": "$59.99",
+            "user_can_purchase_as_gift": True,
+            "hide_discount_pct_for_compliance": False,
+            "included_game_count": 1,
+        },
+    }
+
+
+@pytest.fixture
+def coordinator_mock(hass, game_response_item, game_on_sale_response_item):
     """Fixture to mock the update data coordinator."""
     coordinator = Mock(data={}, hass=hass)
     coordinator.data = {
-        "870780": {
-            "name": "Control",
-            "capsule": "https://steamcdn-a.akamaihd.net/steam/apps/870780/header_292x136.jpg?t=1572428374",
-            "review_score": 0,
-            "review_desc": "No user reviews",
-            "reviews_total": "0",
-            "reviews_percent": 0,
-            "release_date": "1556236800",
-            "release_string": "Coming August 2020",
-            "platform_icons": '<span class="platform_img win"></span>',
-            "subs": [],
-            "type": "Game",
-            "screenshots": [
-                "ss_4cd872ed17a77fee5ddfff766f56a152968030cf.jpg",
-                "ss_5a4d1a304f214a47ca110ceb1172cccaaf997608.jpg",
-                "ss_6b486bb45eea618c0a7fd0781202f3ae3315aa91.jpg",
-                "ss_91b9bb3feeac710f9497de84392b1f7487989669.jpg",
-            ],
-            "review_css": "no_reviews",
-            "priority": 0,
-            "added": 1584991718,
-            "background": "https://steamcdn-a.akamaihd.net/steam/apps/274520/page_bg_generated_v6b.jpg?t=1568727996",
-            "rank": 1000,
-            "tags": [],
-            "is_free_game": False,
-            "win": 1,
-        },
-        "952060": {
-            "name": "RESIDENT EVIL 3",
-            "capsule": "https://steamcdn-a.akamaihd.net/steam/apps/952060/header_292x136.jpg?t=1590098547",
-            "review_score": 6,
-            "review_desc": "Mostly Positive",
-            "reviews_total": "17,331",
-            "reviews_percent": 73,
-            "release_date": "1585886220",
-            "release_string": "Apr 2",
-            "platform_icons": '<span class="platform_img win"></span>',
-            "subs": [
-                {
-                    "id": 437203,
-                    "discount_block": '<div class="discount_block discount_block_large no_discount" data-price-final="5999"><div class="discount_prices"><div class="discount_final_price">$59.99</div></div></div>',
-                    "discount_pct": 0,
-                    "price": 5999,
-                }
-            ],
-            "type": "Game",
-            "screenshots": [
-                "ss_77eda710487b89293f109cf7dcf96b4ffab0d1a1.jpg",
-                "ss_34f01910d65fb171a27e058cb74623c0eb53ba69.jpg",
-                "ss_bec8b7cef716135ea5bbd726a3342ed9ca475b31.jpg",
-                "ss_4f6eaac14b8e02c0a68a9c9f7627dd84cde1abb8.jpg",
-            ],
-            "review_css": "positive",
-            "priority": 0,
-            "added": 1585503915,
-            "background": "https://steamcdn-a.akamaihd.net/steam/apps/952060/page_bg_generated_v6b.jpg?t=1590098547",
-            "rank": 713,
-            "tags": [],
-            "is_free_game": False,
-            "win": 1,
-        },
-        "975150": {
-            "name": "Resolutiion",
-            "capsule": "https://steamcdn-a.akamaihd.net/steam/apps/975150/header_292x136.jpg?t=1590678003",
-            "review_score": 0,
-            "review_desc": "3 user reviews",
-            "reviews_total": "3",
-            "reviews_percent": 100,
-            "release_date": "1590677842",
-            "release_string": "May 28",
-            "platform_icons": '<span class="platform_img win"></span><span class="platform_img mac"></span><span class="platform_img linux"></span>',
-            "subs": [
-                {
-                    "id": 320073,
-                    "discount_block": '<div class="discount_block discount_block_large" data-price-final="1699"><div class="discount_pct">-15%</div><div class="discount_prices"><div class="discount_original_price">$19.99</div><div class="discount_final_price">$16.99</div></div></div>',
-                    "discount_pct": 15,
-                    "price": 1699,
-                }
-            ],
-            "type": "Game",
-            "screenshots": [
-                "ss_08e312cea81092226c8e20c57b4d578ecd4ffa3a.jpg",
-                "ss_66d6693d1e84b2a0932ec3b88f54901eebdac68f.jpg",
-                "ss_e11b14c5e5e6e55bf8fbd064e4a9a8e1b49e528f.jpg",
-                "ss_3405c0136e4c11538c54a0675bea60196aaf66e3.jpg",
-            ],
-            "review_css": "not_enough_reviews",
-            "priority": 0,
-            "added": 1590721175,
-            "background": "https://steamcdn-a.akamaihd.net/steam/apps/1057090/page_bg_generated_v6b.jpg?t=1588789337",
-            "rank": 830,
-            "tags": [],
-            "is_free_game": False,
-            "win": 1,
-            "mac": 1,
-            "linux": 1,
-        },
+        str(game_on_sale_response_item["id"]): game_on_sale_response_item,
+        str(game_response_item["id"]): game_response_item,
     }
     yield coordinator
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,4 +1,5 @@
 """Test the entity classes."""
+
 from custom_components.steam_wishlist import util
 from custom_components.steam_wishlist.entities import (
     SteamGameEntity,
@@ -11,61 +12,42 @@ def test_steamwishlistentity_games_property(manager_mock):
     entity = SteamWishlistEntity(manager_mock)
     expected = [
         {
-            "airdate": "1556236800",
-            "box_art_url": "https://steamcdn-a.akamaihd.net/steam/apps/870780/header_292x136.jpg?t=1572428374",
-            "fanart": "https://steamcdn-a.akamaihd.net/steam/apps/870780/header_292x136.jpg?t=1572428374",
-            "deep_link": "https://store.steampowered.com/app/870780",
+            "title": "Blue Fire",
+            "rating": "Reviews:&nbsp;&nbsp;84% (Very Positive)",
+            "price": "$̶1̶9̶.̶9̶9 $4.99 (75% off)&nbsp;&nbsp;🎫",
             "genres": "",
-            "normal_price": None,
-            "percent_off": 0,
-            "poster": "https://steamcdn-a.akamaihd.net/steam/apps/870780/header_292x136.jpg?t=1572428374",
-            "price": "Price:&nbsp;&nbsp;TBD",
-            "rating": "Reviews:&nbsp;&nbsp;0% (No user reviews)",
-            "release": "Released:&nbsp;&nbsp;Apr 26, 2019",
-            "review_desc": "No user reviews",
-            "reviews_percent": 0,
-            "reviews_total": "0",
-            "sale_price": None,
-            "steam_id": "870780",
-            "title": "Control",
+            "release": "",
+            "airdate": "unknown",
+            "normal_price": "$19.99",
+            "percent_off": 75,
+            "review_desc": "Very Positive",
+            "reviews_percent": 84,
+            "reviews_total": 1623,
+            "sale_price": "$4.99",
+            "steam_id": "1220150",
+            "box_art_url": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1220150/capsule_616x353.jpg?t=1655302580",
+            "fanart": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1220150/capsule_616x353.jpg?t=1655302580",
+            "poster": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1220150/capsule_616x353.jpg?t=1655302580",
+            "deep_link": "https://store.steampowered.com/app/1220150",
         },
         {
-            "airdate": "1585886220",
-            "box_art_url": "https://steamcdn-a.akamaihd.net/steam/apps/952060/header_292x136.jpg?t=1590098547",
-            "deep_link": "https://store.steampowered.com/app/952060",
-            "fanart": "https://steamcdn-a.akamaihd.net/steam/apps/952060/header_292x136.jpg?t=1590098547",
-            "genres": "",
-            "normal_price": 59.99,
-            "percent_off": 0,
-            "poster": "https://steamcdn-a.akamaihd.net/steam/apps/952060/header_292x136.jpg?t=1590098547",
+            "title": "Ghost of Tsushima DIRECTOR'S CUT",
+            "rating": "Reviews:&nbsp;&nbsp;93% (Very Positive)",
             "price": "Price:&nbsp;&nbsp;$59.99",
-            "rating": "Reviews:&nbsp;&nbsp;73% (Mostly Positive)",
-            "release": "Released:&nbsp;&nbsp;Apr 03, 2020",
-            "review_desc": "Mostly Positive",
-            "reviews_percent": 73,
-            "reviews_total": "17,331",
-            "sale_price": None,
-            "steam_id": "952060",
-            "title": "RESIDENT EVIL 3",
-        },
-        {
-            "airdate": "1590677842",
-            "box_art_url": "https://steamcdn-a.akamaihd.net/steam/apps/975150/header_292x136.jpg?t=1590678003",
-            "deep_link": "https://store.steampowered.com/app/975150",
-            "fanart": "https://steamcdn-a.akamaihd.net/steam/apps/975150/header_292x136.jpg?t=1590678003",
             "genres": "",
-            "normal_price": 19.99,
-            "percent_off": 15,
-            "poster": "https://steamcdn-a.akamaihd.net/steam/apps/975150/header_292x136.jpg?t=1590678003",
-            "price": "1̶9̶.̶9̶9 $16.99 (15% off)&nbsp;&nbsp;🎫",
-            "rating": "Reviews:&nbsp;&nbsp;100% (3 user reviews)",
-            "release": "Released:&nbsp;&nbsp;May 28, 2020",
-            "review_desc": "3 user reviews",
-            "reviews_percent": 100,
-            "reviews_total": "3",
-            "sale_price": 16.99,
-            "steam_id": "975150",
-            "title": "Resolutiion",
+            "release": "",
+            "airdate": "unknown",
+            "normal_price": "$59.99",
+            "percent_off": 0,
+            "review_desc": "Very Positive",
+            "reviews_percent": 93,
+            "reviews_total": 33897,
+            "sale_price": None,
+            "steam_id": "2215430",
+            "box_art_url": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/2215430/capsule_616x353.jpg?t=1717622497",
+            "fanart": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/2215430/capsule_616x353.jpg?t=1717622497",
+            "poster": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/2215430/capsule_616x353.jpg?t=1717622497",
+            "deep_link": "https://store.steampowered.com/app/2215430",
         },
     ]
     assert expected == entity.games
@@ -73,9 +55,9 @@ def test_steamwishlistentity_games_property(manager_mock):
 
 def test_steamwishlistentity_games_property_empty_wishlist(manager_mock):
     """Test the games property returns an empty list for an empty wishlist."""
-    manager_mock.coordinator.data = {"success": {}}
+    manager_mock.coordinator.data = {}
     entity = SteamWishlistEntity(manager_mock)
-    assert [] == entity.games
+    assert entity.games == []
 
 
 def test_steamwishlistentity_state(manager_mock):
@@ -86,28 +68,22 @@ def test_steamwishlistentity_state(manager_mock):
 
 def test_steamgameentity_unique_id_property(manager_mock):
     """Test the unique_id property of the entity."""
-    game_id = "975150"
+    game_id = "1220150"
     game = util.get_steam_game(game_id, manager_mock.coordinator.data[game_id])
     entity = SteamGameEntity(manager_mock, game)
-    assert "steam_wishlist_resolutiion" == entity.unique_id
+    assert "steam_wishlist_blue_fire" == entity.unique_id
 
 
 def test_steamgameentity_is_on_property(manager_mock):
     """Test the is_on property of the entity."""
     # Game on sale
-    game_id = "975150"
+    game_id = "1220150"
     game = util.get_steam_game(game_id, manager_mock.coordinator.data[game_id])
     entity = SteamGameEntity(manager_mock, game)
     assert entity.is_on is True
 
     # Game not on sale
-    game_id = "952060"
-    game = util.get_steam_game(game_id, manager_mock.coordinator.data[game_id])
-    entity = SteamGameEntity(manager_mock, game)
-    assert entity.is_on is False
-
-    # Game with no pricing information (unreleased)
-    game_id = "870780"
+    game_id = "2215430"
     game = util.get_steam_game(game_id, manager_mock.coordinator.data[game_id])
     entity = SteamGameEntity(manager_mock, game)
     assert entity.is_on is False
@@ -115,34 +91,34 @@ def test_steamgameentity_is_on_property(manager_mock):
 
 def test_steamgameentity_name_property(manager_mock):
     """Test the name property of the entity."""
-    game_id = "975150"
+    game_id = "1220150"
     game = util.get_steam_game(game_id, manager_mock.coordinator.data[game_id])
     entity = SteamGameEntity(manager_mock, game)
-    assert "Resolutiion" == entity.name
+    assert entity.name == "Blue Fire"
 
 
 def test_steamgameentity_extra_state_attributes_property(manager_mock):
     """Test the device_state_attributes property."""
-    game_id = "975150"
+    game_id = "1220150"
     game = util.get_steam_game(game_id, manager_mock.coordinator.data[game_id])
     entity = SteamGameEntity(manager_mock, game)
     expected = {
-        "airdate": "1590677842",
-        "box_art_url": "https://steamcdn-a.akamaihd.net/steam/apps/975150/header_292x136.jpg?t=1590678003",
-        "deep_link": "https://store.steampowered.com/app/975150",
-        "fanart": "https://steamcdn-a.akamaihd.net/steam/apps/975150/header_292x136.jpg?t=1590678003",
+        "title": "Blue Fire",
+        "rating": "Reviews:&nbsp;&nbsp;84% (Very Positive)",
+        "price": "$̶1̶9̶.̶9̶9 $4.99 (75% off)&nbsp;&nbsp;🎫",
         "genres": "",
-        "normal_price": 19.99,
-        "percent_off": 15,
-        "poster": "https://steamcdn-a.akamaihd.net/steam/apps/975150/header_292x136.jpg?t=1590678003",
-        "price": "1̶9̶.̶9̶9 $16.99 (15% off)&nbsp;&nbsp;🎫",
-        "rating": "Reviews:&nbsp;&nbsp;100% (3 user reviews)",
-        "release": "Released:&nbsp;&nbsp;May 28, 2020",
-        "review_desc": "3 user reviews",
-        "reviews_percent": 100,
-        "reviews_total": "3",
-        "sale_price": 16.99,
-        "steam_id": "975150",
-        "title": "Resolutiion",
+        "release": "",
+        "airdate": "unknown",
+        "normal_price": "$19.99",
+        "percent_off": 75,
+        "review_desc": "Very Positive",
+        "reviews_percent": 84,
+        "reviews_total": 1623,
+        "sale_price": "$4.99",
+        "steam_id": "1220150",
+        "box_art_url": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1220150/capsule_616x353.jpg?t=1655302580",
+        "fanart": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1220150/capsule_616x353.jpg?t=1655302580",
+        "poster": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1220150/capsule_616x353.jpg?t=1655302580",
+        "deep_link": "https://store.steampowered.com/app/1220150",
     }
-    assert expected == entity.extra_state_attributes
+    assert entity.extra_state_attributes == expected

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,166 +1,176 @@
 """Util tests."""
+
 from custom_components.steam_wishlist.util import get_steam_game
 
+not_on_sale = {
+    "item_type": 0,
+    "id": 2215430,
+    "success": 1,
+    "visible": True,
+    "name": "Ghost of Tsushima DIRECTOR'S CUT",
+    "store_url_path": "app/2215430/Ghost_of_Tsushima_DIRECTORS_CUT",
+    "appid": 2215430,
+    "type": 0,
+    "content_descriptorids": [1, 2, 5],
+    "categories": {
+        "supported_player_categoryids": [2, 1, 9, 38],
+        "feature_categoryids": [22, 62],
+        "controller_categoryids": [28],
+    },
+    "reviews": {
+        "summary_filtered": {
+            "review_count": 33897,
+            "percent_positive": 93,
+            "review_score": 8,
+            "review_score_label": "Very Positive",
+        }
+    },
+    "basic_info": {
+        "short_description": "A storm is coming. Venture into the complete Ghost of Tsushima DIRECTOR’S CUT on PC; forge your own path through this open-world action adventure and uncover its hidden wonders. Brought to you by Sucker Punch Productions, Nixxes Software and PlayStation Studios.",
+        "publishers": [
+            {"name": "PlayStation Publishing LLC", "creator_clan_account_id": 40425349}
+        ],
+        "developers": [
+            {"name": "Sucker Punch Productions", "creator_clan_account_id": 40425349},
+            {"name": "Nixxes Software", "creator_clan_account_id": 40425349},
+        ],
+        "franchises": [
+            {"name": "PlayStation Studios", "creator_clan_account_id": 40425349}
+        ],
+    },
+    "assets": {
+        "asset_url_format": "steam/apps/2215430/${FILENAME}?t=1717622497",
+        "main_capsule": "capsule_616x353.jpg",
+        "small_capsule": "capsule_231x87.jpg",
+        "header": "header.jpg",
+        "page_background": "page_bg_generated_v6b.jpg",
+        "hero_capsule": "hero_capsule.jpg",
+        "library_capsule": "library_600x900.jpg",
+        "library_capsule_2x": "library_600x900_2x.jpg",
+        "library_hero": "library_hero.jpg",
+        "library_hero_2x": "library_hero_2x.jpg",
+        "community_icon": "e87b8cbe31f7bc5f40ee6ed94ccfa18f59f04fbc",
+    },
+    "best_purchase_option": {
+        "packageid": 793537,
+        "purchase_option_name": "Ghost of Tsushima DIRECTOR'S CUT",
+        "final_price_in_cents": "5999",
+        "formatted_final_price": "$59.99",
+        "user_can_purchase_as_gift": True,
+        "hide_discount_pct_for_compliance": False,
+        "included_game_count": 1,
+    },
+}
 
-def test_get_steam_game_unreleased_game() -> None:
-    """Test that we get the correct return value for an unreleased game."""
-    game_id = "12007070"
-    game = {
-        "name": "Deathground",
-        "capsule": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1680256324",
-        "review_score": 0,
-        "review_desc": "No user reviews",
-        "reviews_total": "0",
-        "reviews_percent": 0,
-        "release_date": 1684421117,
-        "release_string": "Coming soon",
-        "platform_icons": "",
-        "subs": [],
-        "type": "Game",
-        "screenshots": [],
-        "review_css": "no_reviews",
-        "priority": 0,
-        "added": 1598977652,
-        "background": "",
-        "rank": 1000,
-        "tags": [],
-        "is_free_game": False,
-        "deck_compat": 0,
-        "prerelease": 1,
-        "win": 1,
-    }
-    actual = get_steam_game(game_id, game)
+on_sale = {
+    "item_type": 0,
+    "id": 1220150,
+    "success": 1,
+    "visible": True,
+    "name": "Blue Fire",
+    "store_url_path": "app/1220150/Blue_Fire",
+    "appid": 1220150,
+    "type": 0,
+    "categories": {
+        "supported_player_categoryids": [2],
+        "feature_categoryids": [22, 23, 43, 62],
+        "controller_categoryids": [28],
+    },
+    "reviews": {
+        "summary_filtered": {
+            "review_count": 1623,
+            "percent_positive": 84,
+            "review_score": 8,
+            "review_score_label": "Very Positive",
+        }
+    },
+    "basic_info": {
+        "short_description": "Embark on an extraordinary adventure through the perished world of Penumbra to explore unique temples filled with increasingly difficult 3D platforming challenges, diverse enemies, quests, collectibles, and more. Slash daunting adversaries, leap through deadly traps and master the art of movement.",
+        "publishers": [{"name": "Graffiti Games", "creator_clan_account_id": 35843170}],
+        "developers": [{"name": "Robi Studios", "creator_clan_account_id": 44788856}],
+        "franchises": [
+            {"name": "Blue Fire", "creator_clan_account_id": 44788856},
+            {"name": "Graffiti Games", "creator_clan_account_id": 35843170},
+        ],
+    },
+    "assets": {
+        "asset_url_format": "steam/apps/1220150/${FILENAME}?t=1655302580",
+        "main_capsule": "capsule_616x353.jpg",
+        "small_capsule": "capsule_231x87.jpg",
+        "header": "header.jpg",
+        "page_background": "page_bg_generated_v6b.jpg",
+        "library_capsule": "library_600x900.jpg",
+        "library_capsule_2x": "library_600x900_2x.jpg",
+        "library_hero": "library_hero.jpg",
+        "community_icon": "db04631967d673b165ca802969706557cdbc2d84",
+    },
+    "best_purchase_option": {
+        "packageid": 422570,
+        "purchase_option_name": "Blue Fire",
+        "final_price_in_cents": "499",
+        "original_price_in_cents": "1999",
+        "formatted_final_price": "$4.99",
+        "formatted_original_price": "$19.99",
+        "discount_pct": 75,
+        "active_discounts": [
+            {
+                "discount_amount": "1500",
+                "discount_description": "#discount_desc_preset_special",
+                "discount_end_date": 1734544800,
+            }
+        ],
+        "user_can_purchase_as_gift": True,
+        "hide_discount_pct_for_compliance": False,
+        "included_game_count": 1,
+    },
+}
+
+
+def test_get_steam_game_on_sale(steam_game) -> None:
+    """Verify we get the expected result when a game is on sale."""
+    actual = get_steam_game(on_sale["id"], on_sale)
     expected = {
-        "airdate": 1684421117,
-        "deep_link": f"https://store.steampowered.com/app/{game_id}",
-        "fanart": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1680256324",
+        "airdate": "unknown",
+        "box_art_url": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1220150/capsule_616x353.jpg?t=1655302580",
+        "deep_link": "https://store.steampowered.com/app/1220150",
+        "fanart": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1220150/capsule_616x353.jpg?t=1655302580",
         "genres": "",
-        "box_art_url": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1680256324",
-        "normal_price": None,
+        "normal_price": "$19.99",
+        "percent_off": 75,
+        "poster": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1220150/capsule_616x353.jpg?t=1655302580",
+        "price": "$̶1̶9̶.̶9̶9 $4.99 (75% off)&nbsp;&nbsp;🎫",
+        "rating": "Reviews:&nbsp;&nbsp;84% (Very Positive)",
+        "release": "",
+        "review_desc": "Very Positive",
+        "reviews_percent": 84,
+        "reviews_total": 1623,
+        "sale_price": "$4.99",
+        "steam_id": "1220150",
+        "title": "Blue Fire",
+    }
+    assert expected == actual
+
+
+def test_get_steam_game_not_on_sale(steam_game) -> None:
+    """Verify we get the expected result when a game is not on sale."""
+    actual = get_steam_game(not_on_sale["id"], not_on_sale)
+    expected = {
+        "airdate": "unknown",
+        "box_art_url": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/2215430/capsule_616x353.jpg?t=1717622497",
+        "deep_link": "https://store.steampowered.com/app/2215430",
+        "fanart": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/2215430/capsule_616x353.jpg?t=1717622497",
+        "genres": "",
+        "normal_price": "$59.99",
         "percent_off": 0,
-        "rating": "Reviews:&nbsp;&nbsp;0% (No user reviews)",
-        "poster": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1680256324",
-        "price": "Price:&nbsp;&nbsp;TBD",
-        "release": "Released:&nbsp;&nbsp;May 18, 2023",
-        "review_desc": "No user reviews",
-        "reviews_percent": 0,
-        "reviews_total": "0",
+        "poster": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/2215430/capsule_616x353.jpg?t=1717622497",
+        "price": "Price:&nbsp;&nbsp;$59.99",
+        "rating": "Reviews:&nbsp;&nbsp;93% (Very Positive)",
+        "release": "",
+        "review_desc": "Very Positive",
+        "reviews_percent": 93,
+        "reviews_total": 33897,
         "sale_price": None,
-        "steam_id": game_id,
-        "title": "Deathground",
-    }
-    assert expected == actual
-
-
-def test_get_steam_game_with_sale_price() -> None:
-    """Test that we get the correct return value for a normal on sale game."""
-    game_id = "1262350"
-    game = {
-        "name": "SIGNALIS",
-        "capsule": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1684085470",
-        "review_score": 9,
-        "review_desc": "Overwhelmingly Positive",
-        "reviews_total": "6,844",
-        "reviews_percent": 97,
-        "release_date": 1666879183,
-        "release_string": "Oct 27, 2022",
-        "platform_icons": "",
-        "subs": [
-            {
-                "packageid": 438763,
-                "bundleid": None,
-                "discount_block": "",
-                "discount_pct": 20,
-                "price": "1599",
-            }
-        ],
-        "type": "Game",
-        "screenshots": [],
-        "review_css": "positive",
-        "priority": 0,
-        "added": 1669934204,
-        "background": "",
-        "rank": 558,
-        "tags": [],
-        "is_free_game": False,
-        "deck_compat": "3",
-        "win": 1,
-    }
-    actual = get_steam_game(game_id, game)
-    expected = {
-        "airdate": 1666879183,
-        "deep_link": f"https://store.steampowered.com/app/{game_id}",
-        "fanart": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1684085470",
-        "genres": "",
-        "box_art_url": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1684085470",
-        "normal_price": 19.99,
-        "percent_off": 20,
-        "poster": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1684085470",
-        "price": "1̶9̶.̶9̶9 $15.99 (20% off)&nbsp;&nbsp;🎫",
-        "rating": "Reviews:&nbsp;&nbsp;97% (Overwhelmingly Positive)",
-        "release": "Released:&nbsp;&nbsp;Oct 27, 2022",
-        "review_desc": "Overwhelmingly Positive",
-        "reviews_percent": 97,
-        "reviews_total": "6,844",
-        "sale_price": 15.99,
-        "steam_id": game_id,
-        "title": "SIGNALIS",
-    }
-    assert expected == actual
-
-
-def test_get_steam_game_with_100_percent_discount() -> None:
-    """Test that a free game doesn't cause a division by zero error."""
-    game_id = "1262350"
-    game = {
-        "name": "SIGNALIS",
-        "capsule": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1684085470",
-        "review_score": 9,
-        "review_desc": "Overwhelmingly Positive",
-        "reviews_total": "6,844",
-        "reviews_percent": 97,
-        "release_date": 1666879183,
-        "release_string": "Oct 27, 2022",
-        "platform_icons": "",
-        "subs": [
-            {
-                "packageid": 438763,
-                "bundleid": None,
-                "discount_block": "",
-                "discount_pct": 100,
-                "price": "0",
-            }
-        ],
-        "type": "Game",
-        "screenshots": [],
-        "review_css": "positive",
-        "priority": 0,
-        "added": 1669934204,
-        "background": "",
-        "rank": 558,
-        "tags": [],
-        "is_free_game": False,
-        "deck_compat": "3",
-        "win": 1,
-    }
-    actual = get_steam_game(game_id, game)
-    expected = {
-        "airdate": 1666879183,
-        "deep_link": f"https://store.steampowered.com/app/{game_id}",
-        "fanart": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1684085470",
-        "genres": "",
-        "box_art_url": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1684085470",
-        "normal_price": 0,
-        "percent_off": 100,
-        "poster": f"https://cdn.akamai.steamstatic.com/steam/apps/{game_id}/header_292x136.jpg?t=1684085470",
-        "price": "Price:&nbsp;&nbsp;TBD",
-        "rating": "Reviews:&nbsp;&nbsp;97% (Overwhelmingly Positive)",
-        "release": "Released:&nbsp;&nbsp;Oct 27, 2022",
-        "review_desc": "Overwhelmingly Positive",
-        "reviews_percent": 97,
-        "reviews_total": "6,844",
-        "sale_price": 0.0,
-        "steam_id": game_id,
-        "title": "SIGNALIS",
+        "steam_id": "2215430",
+        "title": "Ghost of Tsushima DIRECTOR'S CUT",
     }
     assert expected == actual

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,133 +2,12 @@
 
 from custom_components.steam_wishlist.util import get_steam_game
 
-not_on_sale = {
-    "item_type": 0,
-    "id": 2215430,
-    "success": 1,
-    "visible": True,
-    "name": "Ghost of Tsushima DIRECTOR'S CUT",
-    "store_url_path": "app/2215430/Ghost_of_Tsushima_DIRECTORS_CUT",
-    "appid": 2215430,
-    "type": 0,
-    "content_descriptorids": [1, 2, 5],
-    "categories": {
-        "supported_player_categoryids": [2, 1, 9, 38],
-        "feature_categoryids": [22, 62],
-        "controller_categoryids": [28],
-    },
-    "reviews": {
-        "summary_filtered": {
-            "review_count": 33897,
-            "percent_positive": 93,
-            "review_score": 8,
-            "review_score_label": "Very Positive",
-        }
-    },
-    "basic_info": {
-        "short_description": "A storm is coming. Venture into the complete Ghost of Tsushima DIRECTOR’S CUT on PC; forge your own path through this open-world action adventure and uncover its hidden wonders. Brought to you by Sucker Punch Productions, Nixxes Software and PlayStation Studios.",
-        "publishers": [
-            {"name": "PlayStation Publishing LLC", "creator_clan_account_id": 40425349}
-        ],
-        "developers": [
-            {"name": "Sucker Punch Productions", "creator_clan_account_id": 40425349},
-            {"name": "Nixxes Software", "creator_clan_account_id": 40425349},
-        ],
-        "franchises": [
-            {"name": "PlayStation Studios", "creator_clan_account_id": 40425349}
-        ],
-    },
-    "assets": {
-        "asset_url_format": "steam/apps/2215430/${FILENAME}?t=1717622497",
-        "main_capsule": "capsule_616x353.jpg",
-        "small_capsule": "capsule_231x87.jpg",
-        "header": "header.jpg",
-        "page_background": "page_bg_generated_v6b.jpg",
-        "hero_capsule": "hero_capsule.jpg",
-        "library_capsule": "library_600x900.jpg",
-        "library_capsule_2x": "library_600x900_2x.jpg",
-        "library_hero": "library_hero.jpg",
-        "library_hero_2x": "library_hero_2x.jpg",
-        "community_icon": "e87b8cbe31f7bc5f40ee6ed94ccfa18f59f04fbc",
-    },
-    "best_purchase_option": {
-        "packageid": 793537,
-        "purchase_option_name": "Ghost of Tsushima DIRECTOR'S CUT",
-        "final_price_in_cents": "5999",
-        "formatted_final_price": "$59.99",
-        "user_can_purchase_as_gift": True,
-        "hide_discount_pct_for_compliance": False,
-        "included_game_count": 1,
-    },
-}
 
-on_sale = {
-    "item_type": 0,
-    "id": 1220150,
-    "success": 1,
-    "visible": True,
-    "name": "Blue Fire",
-    "store_url_path": "app/1220150/Blue_Fire",
-    "appid": 1220150,
-    "type": 0,
-    "categories": {
-        "supported_player_categoryids": [2],
-        "feature_categoryids": [22, 23, 43, 62],
-        "controller_categoryids": [28],
-    },
-    "reviews": {
-        "summary_filtered": {
-            "review_count": 1623,
-            "percent_positive": 84,
-            "review_score": 8,
-            "review_score_label": "Very Positive",
-        }
-    },
-    "basic_info": {
-        "short_description": "Embark on an extraordinary adventure through the perished world of Penumbra to explore unique temples filled with increasingly difficult 3D platforming challenges, diverse enemies, quests, collectibles, and more. Slash daunting adversaries, leap through deadly traps and master the art of movement.",
-        "publishers": [{"name": "Graffiti Games", "creator_clan_account_id": 35843170}],
-        "developers": [{"name": "Robi Studios", "creator_clan_account_id": 44788856}],
-        "franchises": [
-            {"name": "Blue Fire", "creator_clan_account_id": 44788856},
-            {"name": "Graffiti Games", "creator_clan_account_id": 35843170},
-        ],
-    },
-    "assets": {
-        "asset_url_format": "steam/apps/1220150/${FILENAME}?t=1655302580",
-        "main_capsule": "capsule_616x353.jpg",
-        "small_capsule": "capsule_231x87.jpg",
-        "header": "header.jpg",
-        "page_background": "page_bg_generated_v6b.jpg",
-        "library_capsule": "library_600x900.jpg",
-        "library_capsule_2x": "library_600x900_2x.jpg",
-        "library_hero": "library_hero.jpg",
-        "community_icon": "db04631967d673b165ca802969706557cdbc2d84",
-    },
-    "best_purchase_option": {
-        "packageid": 422570,
-        "purchase_option_name": "Blue Fire",
-        "final_price_in_cents": "499",
-        "original_price_in_cents": "1999",
-        "formatted_final_price": "$4.99",
-        "formatted_original_price": "$19.99",
-        "discount_pct": 75,
-        "active_discounts": [
-            {
-                "discount_amount": "1500",
-                "discount_description": "#discount_desc_preset_special",
-                "discount_end_date": 1734544800,
-            }
-        ],
-        "user_can_purchase_as_gift": True,
-        "hide_discount_pct_for_compliance": False,
-        "included_game_count": 1,
-    },
-}
-
-
-def test_get_steam_game_on_sale(steam_game) -> None:
+def test_get_steam_game_on_sale(game_on_sale_response_item) -> None:
     """Verify we get the expected result when a game is on sale."""
-    actual = get_steam_game(on_sale["id"], on_sale)
+    actual = get_steam_game(
+        game_on_sale_response_item["id"], game_on_sale_response_item
+    )
     expected = {
         "airdate": "unknown",
         "box_art_url": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/1220150/capsule_616x353.jpg?t=1655302580",
@@ -151,9 +30,9 @@ def test_get_steam_game_on_sale(steam_game) -> None:
     assert expected == actual
 
 
-def test_get_steam_game_not_on_sale(steam_game) -> None:
+def test_get_steam_game_not_on_sale(game_response_item) -> None:
     """Verify we get the expected result when a game is not on sale."""
-    actual = get_steam_game(not_on_sale["id"], not_on_sale)
+    actual = get_steam_game(game_response_item["id"], game_response_item)
     expected = {
         "airdate": "unknown",
         "box_art_url": "https://shared.cloudflare.steamstatic.com/store_item_assets/steam/apps/2215430/capsule_616x353.jpg?t=1717622497",


### PR DESCRIPTION
This PR should fix #29 . It uses the Steam Web API to retrieve wishlist data now that the old json endpoint was removed.