### PR TITLE
Add steam id to entity ids.

### DIFF
--- a/custom_components/steam_wishlist/entities.py
+++ b/custom_components/steam_wishlist/entities.py
@@ -109,7 +109,7 @@ class SteamGameEntity(CoordinatorEntity, BinarySensorEntity):
         self.manager = manager
         self.slug = slugify(self.game["title"])
 
-        self._attr_unique_id = f"steam_wishlist_{self.slug}"
+        self._attr_unique_id = f"steam_wishlist_{self.coordinator.steam_id}_{self.slug}"
         self._attr_device_info = manager.coordinator.device_info
 
         self.entity_id = f"binary_sensor.{self._attr_unique_id}"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -68,10 +68,11 @@ def test_steamwishlistentity_state(manager_mock):
 
 def test_steamgameentity_unique_id_property(manager_mock):
     """Test the unique_id property of the entity."""
+    manager_mock.coordinator.steam_id = "12345"
     game_id = "1220150"
     game = util.get_steam_game(game_id, manager_mock.coordinator.data[game_id])
     entity = SteamGameEntity(manager_mock, game)
-    assert "steam_wishlist_blue_fire" == entity.unique_id
+    assert "steam_wishlist_12345_blue_fire" == entity.unique_id
 
 
 def test_steamgameentity_is_on_property(manager_mock):


### PR DESCRIPTION
Addresses #34 . Since you can add multiple steam wish lists and those wish lists could have the same games, we need a way to make the binary sensors id's unique.  This will update the id such that `steam_wishlist_<favourite_game_5>` would become `steam_wishlist_<steam_id>_<favourite_game_5>`.  This will ensure unique ids.